### PR TITLE
Fixed non-existent 'skip_reason' key lookup in skip method

### DIFF
--- a/library/callback_plugins/tap.py
+++ b/library/callback_plugins/tap.py
@@ -94,7 +94,7 @@ class CallbackModule(CallbackBase):
         Render a skipped test.
         """
         description = cls._describe(result)
-        directive = '# SKIP {}'.format(result._result['skip_reason'])
+        directive = '# SKIP {}'.format(result._result.get('skip_reason', ''))
         return cls._tap(cls.OK, description, directive=directive)
 
     @classmethod


### PR DESCRIPTION
Ansible version: 2.2.2.0.

I have the following task in my role:

```yaml
- name: "Enabling yum plugins"
  ini_file:
    dest: "/etc/yum/pluginconf.d/{{ item }}.conf"
    section: main
    option: enabled
    value: 1
with_items: "{{ enable_plugins }}"
```

which produces the following warning when `enable_plugins` is an empty list:

```
 [WARNING]: Failure using method (v2_runner_on_skipped) in callback plugin
(<ansible.plugins.callback.tap.CallbackModule object at 0x7f16fe5bbcd0>):
u'skip_reason'
```

and task isn't visible in the TAP output.

I'm not sure if it's an intentional behaviour, but I would prefer to see it with an empty reason:
`ok - ini_file: Enabling yum plugins # SKIP`